### PR TITLE
Fix bug with getting a stale JobQueues query result that resulted in the

### DIFF
--- a/src/Hangfire.Raven/JobQueues/RavenJobQueue.cs
+++ b/src/Hangfire.Raven/JobQueues/RavenJobQueue.cs
@@ -62,6 +62,7 @@ namespace Hangfire.Raven.JobQueues
                         foreach (var job in repository.Query<Hangfire_JobQueues.Mapping, Hangfire_JobQueues>()
                             .Where(fetchCondition)
                             .Where(job => job.Queue == queue)
+                            .Customize(x => x.WaitForNonStaleResultsAsOfNow())
                             .OfType<JobQueue>())
                         {
                             job.FetchedAt = DateTime.UtcNow;


### PR DESCRIPTION
same job being executed multiple times by different worker threads (e.g.
consider a Hangfire job then sending out the same email multiple times).