### PR TITLE
Re-Add Embedded RavenDB Functionality

### DIFF
--- a/Hangfire.Raven.Samples.Embedded/App.config
+++ b/Hangfire.Raven.Samples.Embedded/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Hangfire.Raven.Samples.Embedded/GenericServices.cs
+++ b/Hangfire.Raven.Samples.Embedded/GenericServices.cs
@@ -1,0 +1,10 @@
+﻿namespace Hangfire.Raven.Samples.Embedded
+{
+    public class GenericServices<TType>
+    {
+        public void Method<TMethod>(TType arg1, TMethod arg2)
+        {
+            System.Console.WriteLine("Arg1: {0}, Arg2: {1}", arg1, arg2);
+        }
+    }
+}

--- a/Hangfire.Raven.Samples.Embedded/Hangfire.Raven.Samples.Embedded.csproj
+++ b/Hangfire.Raven.Samples.Embedded/Hangfire.Raven.Samples.Embedded.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7CFDAF39-D58A-4AB7-BF7A-931B858B7A53}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Hangfire.Raven.Samples.Embedded</RootNamespace>
+    <AssemblyName>Hangfire.Raven.Samples.Embedded</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Hangfire.Core, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GenericServices.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Hangfire.Raven\Hangfire.Raven.csproj">
+      <Project>{ba18f6bf-5613-4b9d-a57a-c05c51148ec5}</Project>
+      <Name>Hangfire.Raven</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Hangfire.Raven.Samples.Embedded/Program.cs
+++ b/Hangfire.Raven.Samples.Embedded/Program.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Hangfire.Raven.Storage;
+
+namespace Hangfire.Raven.Samples.Embedded
+{
+    public static class Program
+    {
+        public static int x = 0;
+
+        public static void Main()
+        {
+            try {
+                // you can use Raven Storage and specify the connection string name
+                //GlobalConfiguration.Configuration
+                //    .UseColouredConsoleLogProvider()
+                //    .UseRavenStorage("RavenDebug");
+
+                // you can use Raven Storage and specify the connection string and database name
+                //GlobalConfiguration.Configuration
+                //    .UseColouredConsoleLogProvider()
+                //    .UseRavenStorage("http://localhost:9090", "HangfireConsole");
+
+                // you can use Raven Embedded Storage which runs in memory!
+                GlobalConfiguration.Configuration
+                    .UseColouredConsoleLogProvider()
+                    .UseEmbeddedRavenStorage();
+
+                //you have to create an instance of background job server at least once for background jobs to run
+                var client = new BackgroundJobServer();
+
+                // Run once delayed
+                BackgroundJob.Schedule(() => Console.WriteLine("Delayed Background job:  Hello, world!"), TimeSpan.FromSeconds(20));
+
+                //Run once immediately
+                BackgroundJob.Enqueue(() => Console.WriteLine("Background Job: Hello, world!"));
+                BackgroundJob.Enqueue(() => Console.WriteLine("Background Job: Hello, world again!"));
+                BackgroundJob.Enqueue(() => Console.WriteLine("Background Job: Hello, world a third time!"));
+
+                BackgroundJob.Enqueue(() => Test());
+
+                // Run every minute
+                RecurringJob.AddOrUpdate(() => Test(), Cron.Minutely);
+
+                System.Console.WriteLine("Press Enter to exit...");
+                System.Console.ReadLine();
+            } catch (Exception ex) {
+                throw ex;
+            }
+        }
+
+        [AutomaticRetry(Attempts = 2, LogEvents = true, OnAttemptsExceeded = AttemptsExceededAction.Delete)]
+        public static void Test()
+        {
+            System.Console.WriteLine($"{x++} Cron Job: Hello, world!");
+            //throw new ArgumentException("fail");
+        }
+    }
+}

--- a/Hangfire.Raven.Samples.Embedded/Properties/AssemblyInfo.cs
+++ b/Hangfire.Raven.Samples.Embedded/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Hangfire.Raven.Samples.Embedded")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Hangfire.Raven.Samples.Embedded")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7cfdaf39-d58a-4ab7-bf7a-931b858b7a53")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Hangfire.Raven.Samples.Embedded/Services.cs
+++ b/Hangfire.Raven.Samples.Embedded/Services.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace Hangfire.Raven.Samples.Embedded
+{
+    public class Services
+    {
+        private static readonly Random _random = new Random();
+
+        public void EmptyDefault()
+        {
+        }
+
+        [Queue("critical")]
+        public void EmptyCritical()
+        {
+        }
+
+        [AutomaticRetry(Attempts = 0)]
+        public void Error()
+        {
+            System.Console.WriteLine("Beginning error task...");
+            throw new InvalidOperationException(null, new FileLoadException());
+        }
+
+        [Queue("critical")]
+        public void Random(int number)
+        {
+            int time;
+            lock (_random)
+            {
+                time = _random.Next(10);
+            }
+
+            if (time < 5)
+            {
+                throw new Exception();
+            }
+
+            Thread.Sleep(TimeSpan.FromSeconds(5 + time));
+            System.Console.WriteLine("Finished task: " + number);
+        }
+
+        public void Cancelable(int iterationCount, IJobCancellationToken token)
+        {
+            try
+            {
+                for (var i = 1; i <= iterationCount; i++)
+                {
+                    Thread.Sleep(1000);
+                    System.Console.WriteLine("Performing step {0} of {1}...", i, iterationCount);
+
+                    token.ThrowIfCancellationRequested();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                System.Console.WriteLine("Cancellation requested, exiting...");
+                throw;
+            }
+        }
+        
+        public void Args(string name, int authorId, DateTime createdAt)
+        {
+            System.Console.WriteLine("{0}, {1}, {2}", name, authorId, createdAt);
+        }
+
+        public void Custom(int id, string[] values, CustomObject objects, DayOfWeek dayOfWeek)
+        {
+        }
+
+        public void FullArgs(
+            bool b,
+            int i,
+            char c,
+            DayOfWeek e,
+            string s,
+            TimeSpan t,
+            DateTime d,
+            CustomObject o,
+            string[] sa,
+            int[] ia,
+            long[] ea,
+            object[] na,
+            List<string> sl)
+        {
+        }
+
+        public class CustomObject
+        {
+            public int Id { get; set; }
+            public CustomObject[] Children { get; set; }
+        }
+
+        public void Write(char character)
+        {
+            System.Console.Write(character);
+        }
+
+        public void WriteBlankLine()
+        {
+            System.Console.WriteLine();
+        }
+    }
+}

--- a/Hangfire.Raven.Samples.Embedded/packages.config
+++ b/Hangfire.Raven.Samples.Embedded/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
+</packages>

--- a/Hangfire.Raven.sln
+++ b/Hangfire.Raven.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{8CF2D2F6-BEFE-47FE-B141-0017FC6F97D8}"
 	ProjectSection(SolutionItems) = preProject
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hangfire.Raven.Samples.AspN
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hangfire.Raven.Samples.Console", "samples\Hangfire.Raven.Samples.Console\Hangfire.Raven.Samples.Console.csproj", "{A7691484-4466-4F8C-9B57-C77EA0FF4670}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Raven.Samples.Embedded", "Hangfire.Raven.Samples.Embedded\Hangfire.Raven.Samples.Embedded.csproj", "{7CFDAF39-D58A-4AB7-BF7A-931B858B7A53}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{A7691484-4466-4F8C-9B57-C77EA0FF4670}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7691484-4466-4F8C-9B57-C77EA0FF4670}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7691484-4466-4F8C-9B57-C77EA0FF4670}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CFDAF39-D58A-4AB7-BF7A-931B858B7A53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CFDAF39-D58A-4AB7-BF7A-931B858B7A53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CFDAF39-D58A-4AB7-BF7A-931B858B7A53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CFDAF39-D58A-4AB7-BF7A-931B858B7A53}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -49,6 +55,7 @@ Global
 		{BA18F6BF-5613-4B9D-A57A-C05C51148EC5} = {EF9BFE2C-0386-4EC4-83EC-D7E315F56735}
 		{34B7ED1A-796C-40B8-A8B9-D12D88C8A880} = {F42EDD6E-883B-4067-94AD-72EC7A095BF2}
 		{A7691484-4466-4F8C-9B57-C77EA0FF4670} = {F42EDD6E-883B-4067-94AD-72EC7A095BF2}
+		{7CFDAF39-D58A-4AB7-BF7A-931B858B7A53} = {F42EDD6E-883B-4067-94AD-72EC7A095BF2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1E710484-845C-4FAB-9F3F-2E3384385445}

--- a/samples/Hangfire.Raven.Samples.AspNetCore/Hangfire.Raven.Samples.AspNetCore.csproj
+++ b/samples/Hangfire.Raven.Samples.AspNetCore/Hangfire.Raven.Samples.AspNetCore.csproj
@@ -19,11 +19,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" Version="1.6.17" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Hangfire.Raven.Samples.Console/Program.cs
+++ b/samples/Hangfire.Raven.Samples.Console/Program.cs
@@ -20,10 +20,6 @@ namespace Hangfire.Raven.Samples.Console
                 //    .UseColouredConsoleLogProvider()
                 //    .UseRavenStorage("http://localhost:9090", "HangfireConsole");
 
-                // you can use Raven Embedded Storage which runs in memory!
-                //GlobalConfiguration.Configuration
-                //    .UseColouredConsoleLogProvider()
-                //    .UseEmbeddedRavenStorage();
 
                 //you have to create an instance of background job server at least once for background jobs to run
                 var client = new BackgroundJobServer();

--- a/src/Hangfire.Raven/Hangfire.Raven.csproj
+++ b/src/Hangfire.Raven/Hangfire.Raven.csproj
@@ -29,4 +29,24 @@
     <PackageReference Include="RavenDB.Client" Version="3.5.4" />
   </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+        <PackageReference Include="RavenDB.Database">
+            <Version>3.5.4</Version>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+        <PackageReference Include="RavenDB.Database">
+            <Version>3.5.4</Version>
+        </PackageReference>
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+        <DefineConstants>NETFULL</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+        <DefineConstants>NETFULL</DefineConstants>
+    </PropertyGroup>
+
 </Project>

--- a/src/Hangfire.Raven/Repository.cs
+++ b/src/Hangfire.Raven/Repository.cs
@@ -7,6 +7,9 @@ using Raven.Client;
 using Raven.Client.Document;
 using Raven.Client.Indexes;
 using System.IO;
+#if NETFULL
+using Raven.Client.Embedded;
+#endif
 
 namespace Hangfire.Raven
 {
@@ -16,6 +19,9 @@ namespace Hangfire.Raven
         public string ConnectionUrl { get; set; }
         public string Database { get; set; }
         public string ApiKey { get; set; }
+#if NETFULL
+        public bool Embedded { get; set; }
+#endif
     }
 
     public class RepositoryObserver<T>
@@ -46,28 +52,82 @@ namespace Hangfire.Raven
 
     public class Repository : IRepository
     {
+#if NETFULL
+        private IDocumentStore _documentStore;
+#else
         private DocumentStore _documentStore;
+#endif
 
         private string _database;
 
         public Repository(RepositoryConfig config)
         {
-            if (!string.IsNullOrEmpty(config.ConnectionStringName)) {
-                _documentStore = new DocumentStore {
+#if NETFULL
+            if(config.Embedded && !string.IsNullOrEmpty(config.ConnectionStringName))
+            {
+                _documentStore = new EmbeddableDocumentStore
+                {
+                    RunInMemory = true,
+                    ConnectionStringName = config.ConnectionStringName,
+                };
+
+                ((EmbeddableDocumentStore)_documentStore).Configuration.Storage.Voron.AllowOn32Bits = true;
+            }
+            else if(config.Embedded)
+            {
+                _documentStore = new EmbeddableDocumentStore
+                {
+                    RunInMemory = true,
+                    Url = config.ConnectionUrl,
+                    ApiKey = config.ApiKey,
+                    DefaultDatabase = config.Database
+                };
+
+                ((EmbeddableDocumentStore)_documentStore).Configuration.Storage.Voron.AllowOn32Bits = true;
+            }
+            else if (!string.IsNullOrEmpty(config.ConnectionStringName))
+            {
+                _documentStore = new DocumentStore
+                {
                     ConnectionStringName = config.ConnectionStringName
                 };
-            } else {
-                _documentStore = new DocumentStore {
+            }
+            else
+            {
+                _documentStore = new DocumentStore
+                {
                     Url = config.ConnectionUrl,
                     ApiKey = config.ApiKey,
                     DefaultDatabase = config.Database
                 };
             }
+#else
+            if (!string.IsNullOrEmpty(config.ConnectionStringName))
+            {   
+                _documentStore = new DocumentStore
+                {
+                    ConnectionStringName = config.ConnectionStringName
+                };
+            }
+            else
+            {
+                _documentStore = new DocumentStore
+                {
+                    Url = config.ConnectionUrl,
+                    ApiKey = config.ApiKey,
+                    DefaultDatabase = config.Database
+                };
+            }
+#endif
+
 
             _documentStore.Listeners.RegisterListener(new TakeNewestConflictResolutionListener());
+#if NETFULL
+            _documentStore.Initialize();
+#else
             _documentStore.Initialize(ensureDatabaseExists: false);
-
-            _database = _documentStore.DefaultDatabase;
+#endif
+            _database = config.Database;
         }
 
         public FacetResults GetFacets(string index, IndexQuery query, List<Facet> facets)

--- a/src/Hangfire.Raven/Storage/RavenStorageExtensions.cs
+++ b/src/Hangfire.Raven/Storage/RavenStorageExtensions.cs
@@ -104,5 +104,73 @@ namespace Hangfire.Raven.Storage
 
             return configuration.UseStorage(storage);
         }
+
+#if NETFULL
+        public static IGlobalConfiguration<RavenStorage> UseEmbeddedRavenStorage(this IGlobalConfiguration configuration)
+        {
+            configuration.ThrowIfNull("configuration");
+
+            var config = new RepositoryConfig()
+            {
+                Embedded = true
+            };
+
+            var storage = new RavenStorage(config);
+
+            return configuration.UseStorage(storage);
+        }
+
+        public static IGlobalConfiguration<RavenStorage> UseEmbeddedRavenStorage(this IGlobalConfiguration configuration, string connectionStringName)
+        {
+            configuration.ThrowIfNull("configuration");
+
+            var config = new RepositoryConfig()
+            {
+                Embedded = true,
+                ConnectionStringName = connectionStringName
+            };
+
+            var storage = new RavenStorage(config);
+
+            return configuration.UseStorage(storage);
+        }
+
+        public static IGlobalConfiguration<RavenStorage> UseEmbeddedRavenStorage(this IGlobalConfiguration configuration, string connectionUrl, string database)
+        {
+            configuration.ThrowIfNull("configuration");
+            configuration.ThrowIfNull("connectionUrl");
+            configuration.ThrowIfNull("database");
+
+            var config = new RepositoryConfig()
+            {
+                Embedded = true,
+                ConnectionUrl = connectionUrl,
+                Database = database
+            };
+
+            var storage = new RavenStorage(config);
+
+            return configuration.UseStorage(storage);
+        }
+
+        public static IGlobalConfiguration<RavenStorage> UseEmbeddedRavenStorage(this IGlobalConfiguration configuration, string connectionUrl, string database, RavenStorageOptions options)
+        {
+            configuration.ThrowIfNull("configuration");
+            configuration.ThrowIfNull("connectionUrl");
+            configuration.ThrowIfNull("database");
+            configuration.ThrowIfNull("options");
+
+            var config = new RepositoryConfig()
+            {
+                Embedded = true,
+                ConnectionUrl = connectionUrl,
+                Database = database
+            };
+
+            var storage = new RavenStorage(config, options);
+
+            return configuration.UseStorage(storage);
+        }
+#endif
     }
 }


### PR DESCRIPTION
This PR will re-add the ability to use Embedded RavenDB if the consumer of the library is using .NET Framework (4.5.x or 4.6.x).  Additionally, it adds a sample project using the embedded database and updates the current sample to remove embedding options to eliminate confusion.

The only thing that seems to be problematic is that when you enqueue an item that's not delayed/scheduled or recurring a `ConcurrencyException` is thrown in 90% of cases.  This exception appears to be safely ignorable, but it's currently not handled because I'm still not sure what's causing it.  The trace of this exception appears to be from an etag mismatch when calling `_session.SaveChanges()` within the `Commit()` method of the `RavenWriteOnlyTransaction` class when changing that job's state.  All other methods of running background tasks appear to be working without issues in my initial tests.